### PR TITLE
Fix for missing mqkey.js

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "test": "xo",
-    "start": "node index.js --port 9000 --mq"
+    "start": "node index.js --port 9000"
   },
   "keywords": [
     "gps"


### PR DESCRIPTION
Either provide the lib/mqkey.js file in the repository or don't use the --mq flag in package.json as it gives a nasty erro "Cannot find module './lib/mqkey.js'"